### PR TITLE
Add `bank` utility

### DIFF
--- a/src/SymbolicCompilerPasses.jl
+++ b/src/SymbolicCompilerPasses.jl
@@ -5,7 +5,15 @@ using PreallocationTools
 using SymbolicUtils
 import SymbolicUtils: symtype, vartype, Sym, BasicSymbolic, Term, iscall, operation, arguments, maketerm, Const
 import SymbolicUtils.Code: Code, OptimizationRule, substitute_in_ir, apply_optimization_rules, AbstractMatched,
-    Assignment, CSEState, lhs, rhs, apply_substitution_map, bank
+    Assignment, CSEState, lhs, rhs, apply_substitution_map
+
+function bank(dic, key, value)
+    if haskey(dic, key)
+        dic[key] = vcat(dic[key], value)
+    else
+        dic[key] = value
+    end
+end
 
 include("matmuladd.jl")
 


### PR DESCRIPTION
Allows accumulation of expressions for a single key in a substitution map. Typically with `+`